### PR TITLE
fix: reset OData model pending changes after backend errors

### DIFF
--- a/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
@@ -473,7 +473,9 @@ export default class SpreadsheetUpload extends ManagedObject {
   resetContent() {
     this.payloadArray = [];
     this.payload = [];
-    this.odataHandler.resetContexts();
+    // Pass the model to resetContexts to ensure pending changes are cleared
+    const model = this.binding?.getModel?.();
+    this.odataHandler.resetContexts(model);
     this.spreadsheetUploadDialogHandler.resetContent();
   }
 

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/OData.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/OData.ts
@@ -107,7 +107,7 @@ export default abstract class OData extends ManagedObject {
             if (!component.getContinueOnError()) {
               this.busyDialog.close();
               spreadsheetUploadController.errorsFound = true;
-              this.resetContexts();
+              this.resetContexts(model);
               fnReject('Error while calling the odata service');
               break;
             }
@@ -121,7 +121,7 @@ export default abstract class OData extends ManagedObject {
             await this.waitForDraft();
           }
 
-          this.resetContexts();
+          this.resetContexts(model);
           currentProgressPercent = currentProgressPercent + (batch.length / payloadArray.length) * 100;
           currentProgressValue = currentProgressValue + batch.length;
           (this.busyDialog.getModel('busyModel') as JSONModel).setProperty('/progressPercent', currentProgressPercent);
@@ -142,7 +142,9 @@ export default abstract class OData extends ManagedObject {
       fnResolve();
     } catch (error) {
       this.busyDialog.close();
-      this.resetContexts();
+      // Get binding model for resetContexts
+      const model = binding.getModel();
+      this.resetContexts(model);
       Log.error('Error while calling the odata service', error as Error, 'SpreadsheetUpload: callOdata');
       await this.showInternalErrorDialog(error);
       await this.checkForODataErrors(component.getShowBackendErrorMessages());
@@ -277,7 +279,7 @@ export default abstract class OData extends ManagedObject {
   abstract submitChanges(model: any): Promise<any>;
   abstract waitForCreation(): Promise<any>;
   abstract waitForDraft(): void;
-  abstract resetContexts(): void;
+  abstract resetContexts(model?: any): void;
   abstract getMetadataHandler(): MetadataHandlerV2 | MetadataHandlerV4;
   abstract getLabelList(columns: Columns, odataType: string, excludeColumns: Columns, binding?: any): Promise<ListObject>;
   abstract getKeyList(odataType: string, tableObject: any): Promise<string[]>;

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV2.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV2.ts
@@ -161,9 +161,16 @@ export default class ODataV2 extends OData {
     return this.getMetadataHandler().getKeyList(odataEntityType);
   }
 
-  resetContexts() {
+  resetContexts(model?: any) {
     this.createContexts = [];
     this.createPromises = [];
+
+    // Reset pending changes in the model to prevent "key already exists" errors on re-upload
+    // This follows SAP best practice for error handling - see issue #786
+    if (model && typeof model.resetChanges === 'function') {
+      Log.debug('Resetting pending changes in OData V2 model', undefined, 'SpreadsheetUpload: ODataV2');
+      model.resetChanges();
+    }
   }
 
   getMetadataHandler(): MetadataHandlerV2 {

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV4.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV4.ts
@@ -249,9 +249,16 @@ export default class ODataV4 extends OData {
     return this.getMetadataHandler().getKeyList(odataType);
   }
 
-  resetContexts() {
+  resetContexts(model?: any) {
     this.createContexts = [];
     this.createPromises = [];
+
+    // Reset pending changes in the model to prevent "key already exists" errors on re-upload
+    // This follows SAP best practice for error handling - see issue #786
+    if (model && typeof model.resetChanges === 'function') {
+      Log.debug('Resetting pending changes in OData V4 model', undefined, 'SpreadsheetUpload: ODataV4');
+      model.resetChanges();
+    }
   }
 
   getMetadataHandler(): MetadataHandlerV4 {


### PR DESCRIPTION
- Add model.resetChanges() in ODataV2 and ODataV4 resetContexts()
- Fixes #786