### PR TITLE
feat: add Docker-based test runner for local wdi5 debugging

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,66 @@
+# Docker image for running wdi5 tests locally
+# Replicates the GitHub Actions CI environment (ubuntu + Node 20 + Chrome)
+#
+# Usage:
+#   docker build -f Dockerfile.test -t spreadsheet-test .
+#   docker run --rm spreadsheet-test ordersv2fe 136
+#   docker run --rm -v $(pwd)/examples/reports:/app/examples/reports spreadsheet-test ordersv2fe 136
+
+FROM node:20-slim
+
+# Install system dependencies
+# - chromium + chromium-driver: browser + matching chromedriver (works on arm64 + amd64)
+# - gnome-keyring: Chrome automation requirement
+# - fonts: proper text rendering
+# - netcat: port health checks
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        chromium \
+        chromium-driver \
+        gnome-keyring \
+        fonts-liberation \
+        fonts-noto-color-emoji \
+        libnss3 \
+        libatk-bridge2.0-0 \
+        libgtk-3-0 \
+        libgbm1 \
+        libasound2 \
+        libxshmfence1 \
+        netcat-openbsd \
+        procps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure Chromium for container use
+ENV CHROME_BIN=/usr/bin/chromium
+ENV CHROMEDRIVER_PATH=/usr/bin/chromedriver
+
+WORKDIR /app
+
+# Install SAP CDS CLI globally (matching CI version)
+RUN npm i -g @sap/cds-dk@8.8.2
+
+# Copy everything (monorepo workspaces need full structure for npm install)
+COPY . .
+
+# Recreate .gitignore (excluded by .dockerignore but needed by copy-example-apps.js)
+RUN touch .gitignore
+
+# Remove cds-plugin-ui5 from server (matching CI step)
+RUN cd examples/packages/server && \
+    node -e "const fs = require('fs'); \
+             const pkg = require('./package.json'); \
+             if (pkg.devDependencies) delete pkg.devDependencies['cds-plugin-ui5']; \
+             if (pkg.cds) delete pkg.cds['cds-plugin-ui5']; \
+             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));"
+
+# Remove prepare script and install dependencies
+RUN npm pkg delete scripts.prepare && \
+    npm install --legacy-peer-deps
+
+# Copy entrypoint script to PATH
+RUN cp dev/docker-test.sh /usr/local/bin/docker-test.sh && \
+    chmod +x /usr/local/bin/docker-test.sh
+
+ENTRYPOINT ["docker-test.sh"]
+CMD ["--help"]

--- a/dev/docker-test.sh
+++ b/dev/docker-test.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -e
+
+# ============================================================================
+# Docker Test Runner for UI5 Spreadsheet Importer
+# ============================================================================
+# Replicates the GitHub Actions CI environment for local debugging.
+#
+# Usage:
+#   docker-test.sh <scenario> <ui5version> [extra-wdio-args...]
+#
+# Examples:
+#   docker-test.sh ordersv2fe 136
+#   docker-test.sh ordersv4fe 136 --spec ./test/specs/all/OpenSpreadsheetUploadDialog.test.js
+#   docker-test.sh --help
+#
+# Available scenarios:
+#   ordersv2fe, ordersv4fe, ordersv2fenondraft,
+#   ordersv2freestylenondraft, ordersv2freestylenondraftopenui5,
+#   ordersv4freestyle
+#
+# Available UI5 versions:
+#   136, 120, 108, 96, 84, 71
+# ============================================================================
+
+MARKER_FILE="/app/.test-prepared"
+
+show_help() {
+    echo "============================================="
+    echo " UI5 Spreadsheet Importer - Docker Test Runner"
+    echo "============================================="
+    echo ""
+    echo "Usage: docker run --rm spreadsheet-test <scenario> <ui5version> [wdio-args...]"
+    echo ""
+    echo "Scenarios:"
+    echo "  ordersv2fe                         V2 Fiori Elements (draft)"
+    echo "  ordersv4fe                         V4 Fiori Elements (draft)"
+    echo "  ordersv2fenondraft                 V2 Fiori Elements (non-draft)"
+    echo "  ordersv2freestylenondraft          V2 Freestyle (non-draft)"
+    echo "  ordersv2freestylenondraftopenui5   V2 Freestyle OpenUI5 (non-draft)"
+    echo "  ordersv4freestyle                  V4 Freestyle"
+    echo ""
+    echo "UI5 Versions: 136, 120, 108, 96, 84, 71"
+    echo ""
+    echo "Examples:"
+    echo "  docker run --rm spreadsheet-test ordersv2fe 136"
+    echo "  docker run --rm spreadsheet-test ordersv4fe 136 --spec ./test/specs/all/OpenSpreadsheetUploadDialog.test.js"
+    echo ""
+    echo "Volume mounts for debugging:"
+    echo "  -v \$(pwd)/examples/test:/app/examples/test          Mount test specs (no rebuild needed)"
+    echo "  -v \$(pwd)/examples/reports:/app/examples/reports    Extract timeline reports"
+    echo ""
+}
+
+cleanup() {
+    echo ""
+    echo ">>> Cleaning up background processes..."
+    # Kill all background jobs
+    jobs -p | xargs -r kill 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+# Handle --help
+if [ "$1" == "--help" ] || [ "$1" == "-h" ] || [ -z "$1" ]; then
+    show_help
+    exit 0
+fi
+
+SCENARIO="$1"
+UI5VERSION="$2"
+shift 2
+EXTRA_ARGS="$@"
+
+# If running inside Docker with system Chromium, configure WebdriverIO to use it
+if [ -n "$CHROME_BIN" ] && [ -f "$CHROME_BIN" ]; then
+    export WDIO_CHROME_BINARY="$CHROME_BIN"
+    CHROME_VERSION=$($CHROME_BIN --version 2>/dev/null | grep -oP '\d+\.\d+\.\d+\.\d+' || echo "unknown")
+    echo " Chrome:       $CHROME_BIN ($CHROME_VERSION)"
+fi
+
+# Validate inputs
+if [ -z "$SCENARIO" ] || [ -z "$UI5VERSION" ]; then
+    echo "ERROR: Both <scenario> and <ui5version> are required."
+    echo ""
+    show_help
+    exit 1
+fi
+
+# Get the dynamic port for this scenario+version
+TESTAPPPORT=$(node ./dev/get-port.js "$SCENARIO" "$UI5VERSION")
+if [ -z "$TESTAPPPORT" ]; then
+    echo "ERROR: Could not determine port for scenario=$SCENARIO version=$UI5VERSION"
+    echo "Check dev/testapps.json for valid combinations."
+    exit 1
+fi
+
+echo "============================================="
+echo " Test Configuration"
+echo "============================================="
+echo " Scenario:    $SCENARIO"
+echo " UI5 Version: 1.$UI5VERSION"
+echo " App Port:    $TESTAPPPORT"
+echo " Extra Args:  $EXTRA_ARGS"
+echo "============================================="
+
+# On-demand build: copyTestApps + build (only on first run)
+if [ ! -f "$MARKER_FILE" ]; then
+    echo ""
+    echo ">>> First run: preparing test apps and building component..."
+    echo ">>> This will be skipped on subsequent runs in the same container."
+    echo ""
+
+    echo ">>> Running copyTestApps..."
+    npm run copyTestApps
+
+    echo ">>> Building component..."
+    npm run build
+
+    touch "$MARKER_FILE"
+    echo ">>> Preparation complete."
+else
+    echo ">>> Test apps already prepared (skipping copyTestApps + build)."
+fi
+
+echo ""
+echo ">>> Starting CAP server on port 4004..."
+npm run start:server &
+CAP_PID=$!
+
+echo ">>> Starting UI5 app ${SCENARIO}${UI5VERSION} on port ${TESTAPPPORT}..."
+npm run start:silent --workspace="${SCENARIO}${UI5VERSION}" &
+APP_PID=$!
+
+# Wait for CAP server (port 4004)
+echo ">>> Waiting for CAP server (port 4004)..."
+if ! timeout 60 bash -c 'until nc -z localhost 4004; do sleep 0.5; done'; then
+    echo "ERROR: CAP server did not start within 60 seconds"
+    exit 1
+fi
+echo ">>> CAP server is ready."
+
+# Wait for UI5 app
+echo ">>> Waiting for UI5 app (port ${TESTAPPPORT})..."
+if ! timeout 60 bash -c "until nc -z localhost ${TESTAPPPORT}; do sleep 0.5; done"; then
+    echo "ERROR: UI5 app did not start within 60 seconds on port ${TESTAPPPORT}"
+    exit 1
+fi
+echo ">>> UI5 app is ready."
+
+echo ""
+echo "============================================="
+echo " Running wdi5 tests"
+echo "============================================="
+echo ""
+
+# Run the tests
+TEST_EXIT_CODE=0
+npm run test --workspace=ui5-cc-spreadsheetimporter-sample -- -- --headless "$SCENARIO" "$UI5VERSION" $EXTRA_ARGS || TEST_EXIT_CODE=$?
+
+echo ""
+echo "============================================="
+if [ $TEST_EXIT_CODE -eq 0 ]; then
+    echo " Tests PASSED"
+else
+    echo " Tests FAILED (exit code: $TEST_EXIT_CODE)"
+fi
+echo "============================================="
+
+# Reports location hint
+if [ -d "/app/examples/reports/timeline" ]; then
+    echo ""
+    echo "Timeline report available at: /app/examples/reports/timeline/timeline-report.html"
+    echo "Mount with: -v \$(pwd)/test-results:/app/examples/reports"
+fi
+
+exit $TEST_EXIT_CODE

--- a/examples/test/wdio-base.conf.js
+++ b/examples/test/wdio-base.conf.js
@@ -9,6 +9,8 @@ let version = 0;
 // Check for watch mode flag
 const isWatchMode = process.argv.indexOf("--watch") > -1;
 const isDebugEnabled = true;
+// Docker mode: use system Chromium + chromedriver instead of auto-download
+const isDocker = !!process.env.CHROME_BIN;
 
 for (let index = 0; index < process.argv.length; index++) {
 	const arg = process.argv[index];
@@ -42,8 +44,10 @@ module.exports.config = {
 			"wdio:enforceWebDriverClassic": true,
 			//
 			browserName: "chrome",
-			browserVersion: "stable",
+			// In Docker: skip auto-download, use system Chromium + chromedriver
+			...(isDocker ? {} : { browserVersion: "stable" }),
 			"goog:chromeOptions": {
+				...(isDocker ? { binary: process.env.CHROME_BIN } : {}),
 				args:
 					process.argv.indexOf("--headless") > -1
 						? ["--headless=new", "--window-size=1920,1080", "--no-sandbox"]

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "coypChangelogToDoc": "node ./dev/copy-changelog-to-doc.js",
     "updateAllDependencies": "npm update --workspaces",
     "lint:ui5": "npm run lint:ui5 --workspace=ui5-cc-spreadsheetimporter",
+    "test:docker:build": "docker build -f Dockerfile.test -t spreadsheet-test .",
+    "test:docker": "docker run --rm spreadsheet-test",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Adds `Dockerfile.test` with Node 20 + Chromium + chromedriver (works on arm64 + amd64)
- Adds `dev/docker-test.sh` entrypoint with on-demand app building, server startup, and test execution
- Updates `wdio-base.conf.js` to support Docker mode (uses system Chromium when `CHROME_BIN` is set)
- Adds `test:docker:build` and `test:docker` npm scripts

## Usage
```bash
npm run test:docker:build                    # Build image (~2min)
docker run --rm spreadsheet-test ordersv2fe 136  # Run tests
```

## Test plan
- [x] Docker image builds successfully
- [x] `docker run --rm spreadsheet-test --help` shows usage
- [x] `docker run --rm spreadsheet-test ordersv2fenondraft 136` — all 9 specs pass
- [ ] Verify existing CI tests are not affected (wdio config change is Docker-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)