### PR TITLE
fix: restore valid CLA signatures file

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -1,0 +1,11 @@
+{
+  "signedContributors": [
+    {
+      "name": "marianfoo",
+      "id": 13335743,
+      "created_at": "2026-06-08T00:00:00Z",
+      "repoId": 569313224,
+      "pullRequestNo": 780
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

The CLA Assistant (`.github/workflows/cla.yml`, `contributor-assistant/github-action`) stores signatures in `.github/cla-signers.json` on the **`cla`** branch and `JSON.parse()`s that file on every PR event.

That file had become **empty (0 bytes)**, so the parse throws `Unexpected end of JSON input` and the **`CLAAssistant` check fails on every PR** — including #780 (now merged) and #802.

## Fix

Restore a valid structure and pre-sign the maintainer:

```json
{
  "signedContributors": [
    { "name": "marianfoo", "id": 13335743, "created_at": "...", "repoId": 569313224, "pullRequestNo": 780 }
  ]
}
```

The bot matches contributors by GitHub `id`, so `marianfoo` is recognized as signed and the check passes for their PRs.

## About Claude (co-author)

`Co-Authored-By: Claude …` trailers are **not** GitHub commit authors — the bot reads the commits API `author`/`committer`, not message trailers, and Claude has no GitHub account/id. So Claude is never flagged by the CLA bot and needs **no** signer entry.

## Caveat

This PR targets `cla`, and the bot reads the **base** (still-empty) file when it runs on this PR — so **this PR's own `CLAAssistant` check will fail**. That's the chicken-and-egg of the corrupt file; **merging this PR fixes the bot for all future PRs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)