### PR TITLE
test: add fieldMatchType / column name validation tests (feature + unit)

### DIFF
--- a/examples/packages/ordersv2freestylenondraft/webapp/controller/FieldMatch.controller.js
+++ b/examples/packages/ordersv2freestylenondraft/webapp/controller/FieldMatch.controller.js
@@ -1,0 +1,27 @@
+sap.ui.define(["sap/ui/core/mvc/Controller"], function (Controller) {
+	"use strict";
+
+	return Controller.extend("ui.v2.ordersv2freestylenondraft.controller.FieldMatch", {
+		onOpenFieldMatch: async function () {
+			// Non-standalone with fieldMatchType "label": the component resolves the bound /OrderItems
+			// table from context and matches columns by their plain field label instead of the default
+			// "[key]" bracket notation. The uploaded file uses the bracket format, so in "label" mode
+			// none of the headers match a field label and the component raises a "column not found"
+			// error for every column in the messages dialog instead of writing.
+			this.spreadsheetUpload = await this.getOwnerComponent().createComponent({
+				usage: "spreadsheetImporter",
+				async: true,
+				componentData: {
+					context: this,
+					fieldMatchType: "label"
+				}
+			});
+
+			this.spreadsheetUpload.openSpreadsheetUploadDialog();
+		},
+
+		onNavBack: function () {
+			window.history.back();
+		}
+	});
+});

--- a/examples/packages/ordersv2freestylenondraft/webapp/controller/Launcher.controller.js
+++ b/examples/packages/ordersv2freestylenondraft/webapp/controller/Launcher.controller.js
@@ -9,7 +9,8 @@ sap.ui.define(["sap/ui/core/mvc/Controller", "sap/ui/model/json/JSONModel"], fun
 		{ title: "Create (backend)", hash: "feature/create", flavor: "backend" },
 		{ title: "Locale (decimal separator)", hash: "feature/locale", flavor: "standalone" },
 		{ title: "Errors (validation)", hash: "feature/errors", flavor: "backend" },
-		{ title: "Options (available options)", hash: "feature/options", flavor: "backend" }
+		{ title: "Options (available options)", hash: "feature/options", flavor: "backend" },
+		{ title: "Field Match (label)", hash: "feature/fieldmatch", flavor: "backend" }
 	];
 
 	return Controller.extend("ui.v2.ordersv2freestylenondraft.controller.Launcher", {

--- a/examples/packages/ordersv2freestylenondraft/webapp/manifest.json
+++ b/examples/packages/ordersv2freestylenondraft/webapp/manifest.json
@@ -150,6 +150,11 @@
           "pattern": "feature/options",
           "name": "RouteFeatureOptions",
           "target": "featureOptions"
+        },
+        {
+          "pattern": "feature/fieldmatch",
+          "name": "RouteFeatureFieldMatch",
+          "target": "featureFieldMatch"
         }
       ],
       "targets": {
@@ -210,6 +215,11 @@
         "featureOptions": {
           "viewName": "Options",
           "viewId": "featureOptions",
+          "viewLevel": 1
+        },
+        "featureFieldMatch": {
+          "viewName": "FieldMatch",
+          "viewId": "featureFieldMatch",
           "viewLevel": 1
         }
       }

--- a/examples/packages/ordersv2freestylenondraft/webapp/view/FieldMatch.view.xml
+++ b/examples/packages/ordersv2freestylenondraft/webapp/view/FieldMatch.view.xml
@@ -1,0 +1,26 @@
+<mvc:View controllerName="ui.v2.ordersv2freestylenondraft.controller.FieldMatch"
+    xmlns:mvc="sap.ui.core.mvc" displayBlock="true"
+    xmlns="sap.m">
+    <Page id="fieldMatchPage" title="Feature: Field Match (label)" showNavButton="true" navButtonPress="onNavBack">
+        <content>
+            <VBox class="sapUiSmallMargin">
+                <Text id="fieldMatchHint" text="fieldMatchType 'label' — a labelTypeBrackets file ('UnitPrice[price]') no longer matches any field label, so every column is reported as not found in the messages dialog." class="sapUiSmallMarginBottom"/>
+                <Button id="fieldMatchOpenButton" text="Spreadsheet Upload" type="Emphasized" press="onOpenFieldMatch" class="sapUiSmallMarginBottom"/>
+                <Table id="fieldMatchItemsTable" items="{/OrderItems}" growing="true" growingThreshold="5" noDataText="OrderItems">
+                    <columns>
+                        <Column><Text text="product_ID"/></Column>
+                        <Column><Text text="price"/></Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem>
+                            <cells>
+                                <Text text="{product_ID}"/>
+                                <Text text="{price}"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </VBox>
+        </content>
+    </Page>
+</mvc:View>

--- a/examples/packages/ordersv4freestyle/webapp/controller/FieldMatch.controller.js
+++ b/examples/packages/ordersv4freestyle/webapp/controller/FieldMatch.controller.js
@@ -1,0 +1,27 @@
+sap.ui.define(["sap/ui/core/mvc/Controller"], function (Controller) {
+	"use strict";
+
+	return Controller.extend("ordersv4freestyle.controller.FieldMatch", {
+		onOpenFieldMatch: async function () {
+			// Non-standalone with fieldMatchType "label": the component resolves the bound /OrderItems
+			// table from context and matches columns by their plain field label instead of the default
+			// "[key]" bracket notation. The uploaded file uses the bracket format, so in "label" mode
+			// none of the headers match a field label and the component raises a "column not found"
+			// error for every column in the messages dialog instead of writing.
+			this.spreadsheetUpload = await this.getOwnerComponent().createComponent({
+				usage: "spreadsheetImporter",
+				async: true,
+				componentData: {
+					context: this,
+					fieldMatchType: "label"
+				}
+			});
+
+			this.spreadsheetUpload.openSpreadsheetUploadDialog();
+		},
+
+		onNavBack: function () {
+			window.history.back();
+		}
+	});
+});

--- a/examples/packages/ordersv4freestyle/webapp/controller/Launcher.controller.js
+++ b/examples/packages/ordersv4freestyle/webapp/controller/Launcher.controller.js
@@ -9,7 +9,8 @@ sap.ui.define(["sap/ui/core/mvc/Controller", "sap/ui/model/json/JSONModel"], fun
 		{ title: "Create (backend)", hash: "feature/create", flavor: "backend" },
 		{ title: "Locale (decimal separator)", hash: "feature/locale", flavor: "standalone" },
 		{ title: "Errors (validation)", hash: "feature/errors", flavor: "backend" },
-		{ title: "Options (available options)", hash: "feature/options", flavor: "backend" }
+		{ title: "Options (available options)", hash: "feature/options", flavor: "backend" },
+		{ title: "Field Match (label)", hash: "feature/fieldmatch", flavor: "backend" }
 	];
 
 	return Controller.extend("ordersv4freestyle.controller.Launcher", {

--- a/examples/packages/ordersv4freestyle/webapp/manifest.json
+++ b/examples/packages/ordersv4freestyle/webapp/manifest.json
@@ -180,6 +180,11 @@
           "name": "RouteOptions",
           "pattern": "feature/options",
           "target": ["TargetOptions"]
+        },
+        {
+          "name": "RouteFieldMatch",
+          "pattern": "feature/fieldmatch",
+          "target": ["TargetFieldMatch"]
         }
       ],
       "targets": {
@@ -259,6 +264,13 @@
           "clearControlAggregation": false,
           "viewId": "Options",
           "viewName": "Options"
+        },
+        "TargetFieldMatch": {
+          "viewType": "XML",
+          "transition": "slide",
+          "clearControlAggregation": false,
+          "viewId": "FieldMatch",
+          "viewName": "FieldMatch"
         }
       }
     },

--- a/examples/packages/ordersv4freestyle/webapp/view/FieldMatch.view.xml
+++ b/examples/packages/ordersv4freestyle/webapp/view/FieldMatch.view.xml
@@ -1,0 +1,26 @@
+<mvc:View controllerName="ordersv4freestyle.controller.FieldMatch"
+    xmlns:mvc="sap.ui.core.mvc" displayBlock="true"
+    xmlns="sap.m">
+    <Page id="fieldMatchPage" title="Feature: Field Match (label)" showNavButton="true" navButtonPress="onNavBack">
+        <content>
+            <VBox class="sapUiSmallMargin">
+                <Text id="fieldMatchHint" text="fieldMatchType 'label' — a labelTypeBrackets file ('UnitPrice[price]') no longer matches any field label, so every column is reported as not found in the messages dialog." class="sapUiSmallMarginBottom"/>
+                <Button id="fieldMatchOpenButton" text="Spreadsheet Upload" type="Emphasized" press="onOpenFieldMatch" class="sapUiSmallMarginBottom"/>
+                <Table id="fieldMatchItemsTable" items="{/OrderItems}" growing="true" growingThreshold="5" noDataText="OrderItems">
+                    <columns>
+                        <Column><Text text="product_ID"/></Column>
+                        <Column><Text text="price"/></Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem>
+                            <cells>
+                                <Text text="{product_ID}"/>
+                                <Text text="{price}"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </VBox>
+        </content>
+    </Page>
+</mvc:View>

--- a/examples/test/specs/feature/FieldMatch.test.js
+++ b/examples/test/specs/feature/FieldMatch.test.js
@@ -1,0 +1,61 @@
+const Base = require("../Objects/Base");
+
+let BaseClass = undefined;
+
+/**
+ * Freestyle harness feature test: fieldMatchType / column name validation (issue #58, refs #29).
+ *
+ * The feature page configures the component with fieldMatchType "label", which matches spreadsheet
+ * columns against the plain OData field label instead of the default "[key]" bracket notation.
+ * The uploaded file (TwoRowsNoErrors.xlsx) uses the bracket format and imports cleanly in the
+ * default "labelTypeBrackets" mode (see UploadFileObjectPage). In "label" mode none of the bracket
+ * headers ("UnitPrice[price]", "ID[product_ID]", …) match a field label, so the component raises a
+ * "column does not match any data field" error for every column instead of writing — proving both
+ * the column-name check (#29) and that the fieldMatchType drives the matching (#58).
+ */
+describe("Feature: Field Match (label / column names)", () => {
+	before(async () => {
+		BaseClass = new Base();
+		await browser.goTo({ sHash: "#/feature/fieldmatch" });
+		await BaseClass.dummyWait(1000);
+	});
+
+	it("reports the bracket columns as not found when fieldMatchType is 'label'", async () => {
+		await browser.asControl({ forceSelect: true, selector: { id: new RegExp("fieldMatchOpenButton$") } }).press();
+		await BaseClass.dummyWait(1000);
+		try {
+			await browser.execute(() => {
+				const b = document.getElementById("sap-ui-blocklayer-popup");
+				if (b) b.remove();
+			});
+		} catch (e) {
+			/* nothing */
+		}
+
+		const uploader = await browser.asControl({
+			forceSelect: true,
+			selector: { interaction: "root", controlType: "sap.ui.unified.FileUploader", searchOpenDialogs: true }
+		});
+		// labelTypeBrackets-format file: imports cleanly in the default mode, but every header is a
+		// "<label>[<key>]" string that cannot equal a plain label, so "label" mode rejects them all.
+		const remoteFilePath = await browser.uploadFile("test/testFiles/TwoRowsNoErrors.xlsx");
+		const $uploader = await uploader.getWebElement();
+		const $fileInput = await $uploader.$("input[type=file]");
+		await $fileInput.setValue(remoteFilePath);
+		await BaseClass.dummyWait(1500);
+
+		// the importer raises its "Upload Error" messages dialog because the columns did not match
+		const errorDialog = await browser.asControl({
+			forceSelect: true,
+			selector: { controlType: "sap.m.Dialog", properties: { title: "Upload Error" }, searchOpenDialogs: true }
+		});
+		expect(await errorDialog.isOpen()).toBe(true);
+
+		// and the messages are specifically "column not found" entries for the bracket headers
+		const messagesModel = await errorDialog.getModel("messages");
+		const messagesData = await messagesModel.getData();
+		const messages = Object.values(messagesData._baseObject || messagesData);
+		const bracketColumnsNotFound = messages.filter((message) => message && message.title && (message.title.includes("[product_ID]") || message.title.includes("[price]")));
+		expect(bracketColumnsNotFound.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/ui5-cc-spreadsheetimporter/test/unit/getValueFromRow.test.js
+++ b/packages/ui5-cc-spreadsheetimporter/test/unit/getValueFromRow.test.js
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for Util.getValueFromRow — how the two `fieldMatchType` modes resolve a cell value
+ * from a spreadsheet row (issue #58, refs #29).
+ *
+ * - "label": the row is keyed by the plain field label, so the value is read by label.
+ * - "labelTypeBrackets" (default): the row is keyed by "<label> [<Property>]", so the value is read
+ *   by the bracketed technical token via Util.columnMatchesType (case-insensitive, see
+ *   columnMatchesType.test.js).
+ *
+ * The modes are mutually exclusive on the same headers — a header that matches in one mode is "not
+ * found" (undefined) in the other, which is exactly what makes an unmatched column surface as a
+ * "column not found" error during validation.
+ */
+
+const Util = require('../../src/controller/Util').default;
+
+describe('Util.getValueFromRow (the two fieldMatchTypes)', () => {
+  // labelTypeBrackets headers: "<label>[<key>]"; label headers: plain "<label>"
+  const bracketRow = {
+    'ID[product_ID]': { rawValue: '254' },
+    'UnitPrice[price]': { rawValue: '13.7' }
+  };
+  const labelRow = {
+    ID: { rawValue: '254' },
+    UnitPrice: { rawValue: '13.7' }
+  };
+
+  it("'label' mode resolves the value by the plain field label", () => {
+    expect(Util.getValueFromRow(labelRow, 'UnitPrice', 'price', 'label')).toEqual({ rawValue: '13.7' });
+  });
+
+  it("'labelTypeBrackets' mode resolves the value by the [key] token", () => {
+    expect(Util.getValueFromRow(bracketRow, 'UnitPrice', 'price', 'labelTypeBrackets')).toEqual({ rawValue: '13.7' });
+  });
+
+  it("'labelTypeBrackets' matches the [key] token case-insensitively (e.g. ABAP UPPER CASE template)", () => {
+    const upperRow = { 'UNITPRICE[PRICE]': { rawValue: '13.7' } };
+    expect(Util.getValueFromRow(upperRow, 'UnitPrice', 'price', 'labelTypeBrackets')).toEqual({ rawValue: '13.7' });
+  });
+
+  it('the two modes are mutually exclusive on the same headers', () => {
+    // a bracket header is not resolved in "label" mode ...
+    expect(Util.getValueFromRow(bracketRow, 'UnitPrice', 'price', 'label')).toBeUndefined();
+    // ... and a plain-label header is not resolved in "labelTypeBrackets" mode
+    expect(Util.getValueFromRow(labelRow, 'UnitPrice', 'price', 'labelTypeBrackets')).toBeUndefined();
+  });
+
+  it('returns undefined when the column is not present (basis for the column-not-found error)', () => {
+    expect(Util.getValueFromRow(labelRow, 'Missing', 'doesNotExist', 'label')).toBeUndefined();
+    expect(Util.getValueFromRow(bracketRow, 'Missing', 'doesNotExist', 'labelTypeBrackets')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds tests for **issue #58** — column-name validation (originally requested in #29) and the two `fieldMatchType` modes — at two levels.

### 1. wdi5 feature test (E2E) — new "Field Match" freestyle feature
Uses the new freestyle test harness (`examples/test/HARNESS.md`). A `FieldMatch` feature page is added to **both** harness apps (`ordersv4freestyle` + `ordersv2freestylenondraft`), configured with `fieldMatchType: "label"` (mirroring how `Locale` configures `decimalSeparator`):

- `view/FieldMatch.view.xml` + `controller/FieldMatch.controller.js` (V4 + V2)
- route + target in each `manifest.json`; entry in each `Launcher.controller.js` `FEATURES`

Spec `examples/test/specs/feature/FieldMatch.test.js` deep-links to `#/feature/fieldmatch` and uploads `TwoRowsNoErrors.xlsx` (a `labelTypeBrackets`-format file that imports cleanly in the default mode). In `label` mode the bracket headers no longer match any field label, so the component raises a *"column does not match any data field"* error for every column. The spec asserts the **"Upload Error"** dialog opens **and** that the messages are specifically column-not-found entries for the bracket headers. It runs unchanged on **both OData V2 and V4** via the shared `feature/**.test.js` mapping.

### 2. Jest unit test — `Util.getValueFromRow`
`test/unit/getValueFromRow.test.js` covers how the two `fieldMatchType` modes resolve a cell value from a row: `label` reads by plain label, `labelTypeBrackets` reads by the `[key]` token. It asserts the label-mode extraction (previously untested), the case-insensitive bracket match, the **mutual exclusivity** of the two modes, and the not-found case. This complements the existing `columnMatchesType.test.js` (which only covers the `labelTypeBrackets` matcher).

No component source change is needed — `fieldMatchType` is set through `componentData`.

## Validation
- Unit: `npm run test:unit` (component) → 11 suites / 94 tests pass (incl. the new 5).
- E2E locally (headless Chrome + CAP): `FieldMatch.test.js` passes on V4 and V2; `Launcher`/`Errors`/`Options` feature specs still pass (no regression).
- **CI green** on the prior commit: the feature spec passed on every freestyle job — `ordersv2freestylenondraft` (71/120/136) and `ordersv4freestyle` (120/136). (The Jest `test:unit` suite is a local/dev suite, not currently wired into CI.)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)
