### PR TITLE
fix: reset only importer-created entities, preserve user's pending changes

### DIFF
--- a/examples/test/specs/all/UploadFilePreserveEdit.test.js
+++ b/examples/test/specs/all/UploadFilePreserveEdit.test.js
@@ -1,0 +1,228 @@
+// Regression test for issue #231:
+// An upload must NOT discard the user's unrelated pending changes.
+//
+// Scenario (OData V2, Fiori Elements, non-draft Object Page):
+//   1. enter edit mode
+//   2. make a manual change to an Order *header* field -> a pending change on the model
+//   3. upload a spreadsheet that has validation errors -> the importer raises its "Upload Error"
+//      dialog (nothing is created/submitted), and closing that dialog runs the importer's cleanup
+//      (resetContent -> resetContexts)
+//   4. the user's header pending change must still be there afterwards
+//
+// Before the fix, resetContexts() called model.resetChanges() (no args) and wiped ALL pending
+// changes - including the user's edit. The fix resets ONLY the importer's own created/updated rows
+// (here: none), so the user's edit survives.
+//
+// Why the error path (and not a successful upload): on a *successful* V2 upload the importer's
+// submitChanges() flushes the whole model, so the user's edit is committed (not observably lost).
+// The data loss only manifests when resetContexts() runs while the edit is still pending.
+//
+// Guarded to the ordersv2fenondraft scenario because the "all/**" glob is shared with v2fe/v4fe.
+const { default: _ui5Service } = require("wdio-ui5-service");
+const ui5Service = new _ui5Service();
+const FEV2ND = require("../Objects/FEV2ND");
+const Base = require("./../Objects/Base");
+
+let FE = undefined;
+let BaseClass = undefined;
+let editedValue = undefined; // the unique value we write into the header field
+
+// Read the header context's pending-change state from inside the browser (the repo's established
+// pattern; avoids the unproven wdi5 model-method bridge). Returns plain, serializable data.
+async function readHeaderPending(tableId, prop) {
+	return browser.execute(
+		function (tableId, prop) {
+			function byId(id) {
+				const E = sap.ui.require("sap/ui/core/Element");
+				return E && E.getElementById ? E.getElementById(id) : sap.ui.getCore().byId(id);
+			}
+			const oTable = byId(tableId);
+			if (!oTable) return { error: "table not found" };
+			const oModel = oTable.getModel();
+			const oHeaderCtx = oTable.getBindingContext();
+			if (!oHeaderCtx) return { error: "no header binding context" };
+			const key = oHeaderCtx.getPath().replace(/^\//, "");
+			const pending = oModel.getPendingChanges() || {};
+			const entry = pending[key];
+			return {
+				key: key,
+				hasHeaderChange: Object.prototype.hasOwnProperty.call(pending, key),
+				changedValue: entry ? entry[prop] : undefined,
+				allKeys: Object.keys(pending)
+			};
+		},
+		tableId,
+		prop
+	);
+}
+
+describe("Preserve user's pending changes on upload (#231)", () => {
+	before(function () {
+		const scenario = global.scenario;
+		if (!scenario || !scenario.startsWith("ordersv2fenondraft")) {
+			this.skip();
+			return;
+		}
+		FE = new FEV2ND();
+		BaseClass = new Base();
+	});
+
+	it("go to object page", async () => {
+		const hash = `#/${FE.entitySet}(${FE.entityObjectPage})`;
+		await browser.goTo({ sHash: hash });
+		await BaseClass.dummyWait(1000);
+		// Running this spec in isolation means a cold app: wait until the object page (edit button)
+		// has actually rendered before interacting with it.
+		await browser.waitUntil(
+			async () => {
+				const btn = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageEditButton } });
+				return !!btn && !!btn._domId;
+			},
+			{ timeout: 90000, interval: 1000, timeoutMsg: "Object page edit button did not render" }
+		);
+	});
+
+	it("go to edit mode", async () => {
+		await BaseClass.pressById(FE.objectPageEditButton);
+		await BaseClass.dummyWait(3000);
+
+		// if the edit button is still visible, refresh the page and try again (mirrors UploadFileObjectPage)
+		const object = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageEditButton } });
+		if (object._domId) {
+			await browser.refresh();
+			await ui5Service.injectUI5();
+			await browser.waitUntil(
+				async () => {
+					const btn = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageEditButton } });
+					return !!btn && !!btn._domId;
+				},
+				{ timeout: 90000, interval: 1000, timeoutMsg: "Object page edit button did not render after refresh" }
+			);
+		}
+		const object2 = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageEditButton } });
+		if (object2._domId) {
+			await BaseClass.pressById(FE.objectPageEditButton);
+			await BaseClass.dummyWait(3000);
+		}
+		// confirm we actually entered edit mode (save button present) before continuing
+		await browser.waitUntil(
+			async () => {
+				const save = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageSaveButton } });
+				return !!save && !!save._domId;
+			},
+			{ timeout: 30000, interval: 1000, timeoutMsg: "Did not enter edit mode (save button not found)" }
+		);
+	});
+
+	it("make an unrelated manual edit on the order header", async () => {
+		// Set OrderNo to a value guaranteed to differ from the current one, so a pending change is
+		// created regardless of the backend's current value.
+		const result = await browser.execute(function (tableId) {
+			function byId(id) {
+				const E = sap.ui.require("sap/ui/core/Element");
+				return E && E.getElementById ? E.getElementById(id) : sap.ui.getCore().byId(id);
+			}
+			const oTable = byId(tableId);
+			const oModel = oTable.getModel();
+			const oHeaderCtx = oTable.getBindingContext();
+			const oldValue = oModel.getProperty("OrderNo", oHeaderCtx) || "";
+			const newValue = oldValue + "-E231";
+			oModel.setProperty("OrderNo", newValue, oHeaderCtx);
+			return { newValue: newValue, headerPath: oHeaderCtx.getPath() };
+		}, FE.objectPageOrderItems);
+		editedValue = result.newValue;
+		expect(result.headerPath).toBeDefined();
+
+		// confirm the pending change is registered before we upload
+		const before = await readHeaderPending(FE.objectPageOrderItems, "OrderNo");
+		expect(before.hasHeaderChange).toBe(true);
+		expect(before.changedValue).toBe(editedValue);
+	});
+
+	it("upload a file with validation errors (raises the Upload Error dialog)", async () => {
+		await BaseClass.dummyWait(500);
+		await BaseClass.pressById(FE.objectPageSpreadsheetuploadButton);
+		await browser.asControl({
+			selector: { controlType: "sap.m.Dialog", properties: { contentWidth: "40vw" }, searchOpenDialogs: true }
+		});
+		try {
+			await browser.execute(function () {
+				const b = document.getElementById("sap-ui-blocklayer-popup");
+				if (b) b.remove();
+			});
+		} catch (e) {
+			/* nothing */
+		}
+
+		const uploader = await browser.asControl({
+			forceSelect: true,
+			selector: { interaction: "root", controlType: "sap.ui.unified.FileUploader", searchOpenDialogs: true }
+		});
+		const remoteFilePath = await browser.uploadFile("test/testFiles/TwoRowsErrors.xlsx");
+		const $uploader = await uploader.getWebElement();
+		const $fileInput = await $uploader.$("input[type=file]");
+		await $fileInput.setValue(remoteFilePath);
+
+		await browser.asControl({ selector: { controlType: "sap.m.Button", properties: { text: "Upload" }, searchOpenDialogs: true } }).press();
+
+		// the "Upload Error" messages dialog only opens when validation found errors -> nothing was
+		// created or submitted; the user's pending edit is therefore still untouched at this point.
+		await browser.waitUntil(
+			async () => {
+				const dlg = await browser.asControl({
+					forceSelect: true,
+					selector: { controlType: "sap.m.Dialog", properties: { title: "Upload Error" }, searchOpenDialogs: true }
+				});
+				return !!dlg && !!dlg._domId && (await dlg.isOpen());
+			},
+			{ timeout: 30000, interval: 500, timeoutMsg: "Upload Error dialog did not appear" }
+		);
+	});
+
+	it("close the error dialog (runs the importer cleanup / resetContexts)", async () => {
+		try {
+			await browser.execute(function () {
+				const b = document.getElementById("sap-ui-blocklayer-popup");
+				if (b) b.remove();
+			});
+		} catch (e) {
+			/* nothing */
+		}
+		// fire the press handler directly (the MessageView list can intercept a DOM click in headless):
+		// Close -> onCloseMessageDialog -> spreadsheetUploadController.resetContent() -> resetContexts()
+		const closeBtn = await browser.asControl({
+			forceSelect: true,
+			selector: { controlType: "sap.m.Button", properties: { text: "Close" }, searchOpenDialogs: true }
+		});
+		await closeBtn.firePress();
+		await BaseClass.dummyWait(1500);
+	});
+
+	it("the manual header edit must still be pending after the cleanup (#231)", async () => {
+		const after = await readHeaderPending(FE.objectPageOrderItems, "OrderNo");
+		console.log("AFTER-CLEANUP PENDING: " + JSON.stringify(after));
+		// Buggy code: resetChanges() wiped everything -> hasHeaderChange === false (RED).
+		// Fixed code: only the importer's own rows are reset (here none) -> the edit survives (GREEN).
+		expect(after.hasHeaderChange).toBe(true);
+		expect(after.changedValue).toBe(editedValue);
+	});
+
+	after(async () => {
+		// discard the manual edit so we don't pollute other specs / the backend
+		try {
+			await browser.execute(function (tableId) {
+				function byId(id) {
+					const E = sap.ui.require("sap/ui/core/Element");
+					return E && E.getElementById ? E.getElementById(id) : sap.ui.getCore().byId(id);
+				}
+				const oTable = byId(tableId);
+				const oModel = oTable && oTable.getModel();
+				if (oModel && oModel.resetChanges) {
+					oModel.resetChanges();
+				}
+			}, FE.objectPageOrderItems);
+		} catch (error) {
+			/* best-effort cleanup */
+		}
+	});
+});

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/OData.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/OData.ts
@@ -138,6 +138,11 @@ export default abstract class OData extends ManagedObject {
           }
           if (component.getContinueOnError()) {
             Log.error('Error while calling the odata service', error as Error, 'SpreadsheetUpload: callOdata');
+            // A thrown error skipped this batch's normal resetContexts call above. Clean up the
+            // batch's tracked/queued changes now, or they bleed into the next iteration (the next
+            // submit would re-send the failed batch's queued requests -> duplicate rows, and stale
+            // rejected createPromises would poison the next waitForCreation).
+            this.resetContexts(model);
           } else {
             // throw error to stop processing
             throw error;

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV2.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV2.ts
@@ -19,6 +19,10 @@ export default class ODataV2 extends OData {
   submitChangesResponse: any;
   private metadataHandler: MetadataHandlerV2;
   private requestObjects: ODataV2RequestObjects;
+  // Entities this upload itself created/updated in the current batch. Used to clean up ONLY the
+  // importer's own changes, never the user's unrelated pending changes (issues #231 / #786).
+  private createdEntryContexts: any[] = [];
+  private updatedEntityPaths: string[] = [];
 
   constructor(spreadsheetUploadController: SpreadsheetUpload, messageHandler: MessageHandler, util: Util) {
     super(spreadsheetUploadController, messageHandler, util);
@@ -38,6 +42,11 @@ export default class ODataV2 extends OData {
             reject(error);
           }
         });
+        // Track our own created entry so cleanup targets ONLY these rows, never the
+        // user's unrelated pending changes (issues #231 / #786).
+        if (context) {
+          this.createdEntryContexts.push(context);
+        }
       });
     };
     return submitChangesPromise(this.customBinding, payload);
@@ -127,6 +136,8 @@ export default class ODataV2 extends OData {
     });
 
     this.createPromises.push(updatePromise);
+    // Track the entity we updated so cleanup targets ONLY our change (issues #231 / #786).
+    this.updatedEntityPaths.push(entityPath);
   }
 
   async checkForErrors(model: any, binding: any, showBackendErrorMessages: Boolean): Promise<boolean> {
@@ -138,6 +149,13 @@ export default class ODataV2 extends OData {
       // messages from the message model first (checkForODataErrors does that and only opens
       // the dialog when messages exist) — handing it an empty array shows an empty dialog.
       await this.checkForODataErrors(showBackendErrorMessages);
+    } else {
+      // Successful submit: our update requests were consumed by the batch, so there is nothing of
+      // OURS left at those paths. Clear the tracker now - otherwise the per-batch resetContexts on
+      // the success path would call resetChanges on those entities and could only ever hit the
+      // USER's pending changes there (e.g. an unsaved edit on an entity the spreadsheet also
+      // updated) - the exact #231 data loss this fix exists to prevent.
+      this.updatedEntityPaths = [];
     }
     return errorFound;
   }
@@ -252,14 +270,56 @@ export default class ODataV2 extends OData {
   }
 
   resetContexts(model?: any) {
+    // Snapshot what THIS importer created/updated this batch, then clear the trackers.
+    const createdContexts = (this.createdEntryContexts || []).filter(context => context && typeof context.getPath === 'function');
+    const updatedPaths = Array.from(new Set(this.updatedEntityPaths || []));
     this.createContexts = [];
     this.createPromises = [];
+    this.createdEntryContexts = [];
+    this.updatedEntityPaths = [];
 
-    // Reset pending changes in the model to prevent "key already exists" errors on re-upload
-    // This follows SAP best practice for error handling - see issue #786
-    if (model && typeof model.resetChanges === 'function') {
-      Log.debug('Resetting pending changes in OData V2 model', undefined, 'SpreadsheetUpload: ODataV2');
-      model.resetChanges();
+    // Reset ONLY the entities this importer touched - never the user's unrelated pending changes
+    // (e.g. a field edited in Fiori Elements edit mode). A blunt model.resetChanges() would wipe
+    // those too. See issues #231 (data loss) and #786 ("key already exists" on re-upload).
+    // One resetChanges call per model with the whole path array - resetChanges accepts an array,
+    // and every call ends in a forced checkUpdate(true) over ALL bindings, so per-row calls would
+    // cost a full-model refresh per row.
+    const createdPathsByModel = new Map<any, string[]>();
+    for (const context of createdContexts) {
+      const ctxModel = (typeof context.getModel === 'function' && context.getModel()) || model;
+      if (!ctxModel || typeof ctxModel.resetChanges !== 'function') {
+        continue;
+      }
+      const paths = createdPathsByModel.get(ctxModel) || [];
+      paths.push(context.getPath());
+      createdPathsByModel.set(ctxModel, paths);
+    }
+    createdPathsByModel.forEach((paths, ctxModel) => {
+      try {
+        // SAP's documented replacement for the (deprecated) deleteCreatedEntry - see its JSDoc:
+        //   oModel.resetChanges([oContext.getPath()], undefined, true)
+        // resetChanges(aPath, bAll, bDeleteCreatedEntities): scoped to our paths, so the user's other
+        // pending changes are untouched. bDeleteCreatedEntities (since 1.95) fully removes the
+        // still-transient created rows; on older lines resetChanges([rootPath]) already drops them
+        // from the pending changes and aborts the queued POSTs. After a successful submit the rows
+        // are already persisted, so this is a harmless no-op.
+        ctxModel.resetChanges(paths, undefined, true);
+      } catch (error) {
+        // a failed reset leaves transient created rows behind -> next upload may hit
+        // "key already exists" (#786); keep this visible at default log level
+        Log.warning(`Could not reset created entries (${paths.length})`, error as Error, 'SpreadsheetUpload: ODataV2');
+      }
+    });
+
+    if (updatedPaths.length > 0 && model && typeof model.resetChanges === 'function') {
+      try {
+        // Only reached when the batch FAILED or never submitted (the tracker is cleared on
+        // successful submits in checkForErrors): abort our queued (deferred) update requests.
+        // bAll=true so the deferred request itself is aborted, not only entity changes.
+        model.resetChanges(updatedPaths, true);
+      } catch (error) {
+        Log.warning('Could not reset updated entities', error as Error, 'SpreadsheetUpload: ODataV2');
+      }
     }
   }
 

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV4.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV4.ts
@@ -170,10 +170,20 @@ export default class ODataV4 extends OData {
   async checkForErrors(model: any, binding: any, showBackendErrorMessages: Boolean): Promise<boolean> {
     // if the binding has pending changes, a error occured
     if (this.customBinding.hasPendingChanges()) {
-      // delete all the created context
-      this.createContexts.forEach(async context => {
-        await context.delete(this.updateGroupId);
-      });
+      // Delete the still-TRANSIENT (failed) created contexts and WAIT for them, so the importer's
+      // update group is actually clean before resetContexts() runs. Persisted contexts (rows the
+      // backend DID create) must be left alone: deleting them would destroy real records, and their
+      // delete() in our API group would only settle after a submitBatch that never comes on this
+      // path - the await would hang forever. Transient deletes resolve client-side immediately.
+      try {
+        await Promise.all(
+          this.createContexts
+            .filter(context => typeof context.isTransient === 'function' && context.isTransient())
+            .map(context => context.delete(this.updateGroupId))
+        );
+      } catch (error) {
+        Log.error('Error deleting created contexts after failed upload', error as Error, 'SpreadsheetUpload: ODataV4');
+      }
       // The ODataMessagesDialog renders exactly the data it is handed, so read the backend
       // messages from the message model first (checkForODataErrors does that and only opens
       // the dialog when messages exist) — calling displayMessages() without data shows an
@@ -261,11 +271,18 @@ export default class ODataV4 extends OData {
     this.createContexts = [];
     this.createPromises = [];
 
-    // Reset pending changes in the model to prevent "key already exists" errors on re-upload
-    // This follows SAP best practice for error handling - see issue #786
+    // Reset ONLY the importer's own update group - never a no-arg resetChanges(), which targets the
+    // model's default ($auto) group and would discard the user's unrelated edits (issue #231).
+    // checkForErrors() already deletes our created contexts on the error path; this additionally
+    // cleans the outer-catch path (where checkForErrors never ran) and any leftover update changes,
+    // preventing "key already exists" on re-upload (#786).
     if (model && typeof model.resetChanges === 'function') {
-      Log.debug('Resetting pending changes in OData V4 model', undefined, 'SpreadsheetUpload: ODataV4');
-      model.resetChanges();
+      try {
+        Log.debug(`Resetting pending changes in OData V4 update group ${this.updateGroupId}`, undefined, 'SpreadsheetUpload: ODataV4');
+        model.resetChanges(this.updateGroupId);
+      } catch (error) {
+        Log.debug('resetChanges for importer update group skipped', error as Error, 'SpreadsheetUpload: ODataV4');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #231. Uploading a spreadsheet — or just closing the importer's validation-error dialog — could silently discard the user's **unrelated** pending changes (e.g. a field they had edited in a Fiori Elements Object Page edit session before uploading).

## Root cause

The importer's cleanup, `resetContexts()`, called a blunt **`model.resetChanges()`** (no arguments). On the shared OData model that resets *every* pending change, not just the importer's own — so an in-progress user edit was wiped whenever the importer cleaned up (after an upload, on the error/cancel path, or on dialog close).

That blunt reset was itself the fix for #786 ("key already exists" on re-upload), so it can't simply be removed — it has to be **scoped to the importer's own changes**.

## Fix

Reset only the entities the importer itself created/updated.

**OData V2** (`ODataV2.ts`)
- Track each `createEntry` context (`createdEntryContexts`) and each updated entity path (`updatedEntityPaths`).
- In `resetContexts()` reset only those: `resetChanges([path], undefined, true)` per created row, `resetChanges(paths, true)` for updates (`bAll:true` also aborts the deferred `update()` request). The user's other pending changes are left intact.
- `resetChanges([path], undefined, true)` is exactly SAP's documented replacement for the deprecated `deleteCreatedEntry`. V2 has **no** group-scoped reset (unlike V4), so path-based reset is the documented mechanism — not a workaround.

**OData V4** (`ODataV4.ts`)
- `checkForErrors()` now **awaits** the created-context deletions (was a fire-and-forget `forEach(async …)` that raced the subsequent reset).
- `resetContexts()` scopes the reset to the importer's **own update group** — `resetChanges(this.updateGroupId)` — instead of the model's default (`$auto`) group, which can hold the user's edits. This mirrors SAP's documented Save/Cancel "Batch Control" pattern (the importer already isolates its writes via `$$updateGroupId`).

## API / best-practice validation

The approach was checked against the official UI5 API reference (`api.json`), the SAP Help developer guide, and the actual UI5 `ODataModel` source at tags **1.71.76 / 1.84.20 / 1.95.0** (minUI5Version is 1.84.20; CI also runs 1.71):
- V2 `resetChanges([rootPath], …)` removes a still-transient `createEntry` row and aborts its queued POST on **all** supported lines (`bDeleteCreatedEntities` is `@since 1.95`, but the row is dropped from pending changes even on 1.71/1.84) — so #786 stays fixed without the deprecated `deleteCreatedEntry`.
- V4 `resetChanges(sGroupId)` is group-scoped (`@since 1.39`), and `await Promise.all(ctxs.map(c => c.delete(group)))` is the idiomatic mass-delete for list-binding contexts.

## Testing

New regression test `examples/test/specs/all/UploadFilePreserveEdit.test.js` (guarded to `ordersv2fenondraft`): with a pending Order-header edit, an upload that raises the "Upload Error" dialog must not discard that edit when the dialog is closed. Verified **red → green** — edit wiped on the old code, preserved with the fix.

Regression-checked locally (UI5 1.136, headless):
- `ordersv2fenondraft` normal Object Page upload — 16/16 ✓
- `ordersv4fe` Object Page upload (create) — 16/16 ✓
- `ordersv4fe` download + update (draft, null/empty markers) — 8/8 ✓
- `ui5lint`: 0 errors · `prettier --check`: clean

## Known limitation (separate from this fix)

On a **successful** V2 upload the importer's `submitChanges()` still flushes the whole model, so a user's unrelated pending edit gets *committed* (not lost). Fully isolating the V2 writes in a dedicated deferred request group (the V2 analogue of V4's `$$updateGroupId`) would avoid that, but it's a larger, scenario-sensitive change; this PR fixes the data-loss path reported in #231.

## Refs
- Fixes #231
- Background: #214, #223 (original popup workaround), #786 / #792 (the `resetChanges()` this scopes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)