### PR TITLE
chore: add launchpad dev flow to serve all test apps with one command

### DIFF
--- a/docs/pages/Development/GettingStarted.md
+++ b/docs/pages/Development/GettingStarted.md
@@ -45,6 +45,26 @@ npm install --legacy-peer-deps
 
 ## Start Developing
 
+### Start everything in one Launchpad (recommended)
+
+The fastest way to get going is a single command that starts the CAP server **and** serves all the main test apps behind a Fiori Launchpad — no separate terminals or per-app ports:
+
+```sh
+npm run start:launchpad
+```
+
+This boots `cds watch` and automatically opens the Launchpad at **<http://localhost:4004/launchpad.html>** (the CAP welcome page at <http://localhost:4004/> also gets a "Sandbox Launchpad" link). Every app is mounted into the same CAP process and starts together with the server.
+
+How it works:
+
+- [`cds-plugin-ui5`](https://www.npmjs.com/package/cds-plugin-ui5) mounts every UI5 app that is a (dev)dependency of the CAP server (`examples/packages/server`) at `/<sap.app.id>`.
+- [`cds-launchpad-plugin`](https://www.npmjs.com/package/cds-launchpad-plugin) serves the Launchpad and auto-generates a tile for each app from its `sap.app.crossNavigation.inbounds` (the manual link tiles live in `examples/packages/server/app/appconfig.json`).
+- The `start:launchpad` script sets `CDS_PLUGIN_UI5_MODULES={}`, which makes the apps serve **from source with live reload** (the regular `cds watch` / Docker live demo serves the pre-built `dist` instead — see [Sample Apps](./SampleApps.md)). As with the standalone flow, keep the `ui5-cc-spreadsheetimporter/dist` folder empty (only `.gitkeep`) so the importer is served live from source — see [Build Step](#build-step) below.
+
+The apps shown in the Launchpad are the ones that are both a devDependency of `examples/packages/server` and have a `crossNavigation.inbounds` entry in their `manifest.json` (currently `ordersv2fe`, `ordersv4fe`, `ordersv4freestyle` and `anyupload`).
+
+> The Launchpad flow is for interactive development. The wdi5 tests still launch each app standalone on its own port (see [Start UI5 Apps](#start-ui5-apps) and [wdi5 Tests](./wdi5.md)).
+
 ### Start CAP server
 
 The CAP Server is currently very basic and provides an Order Entity with OrderItems. All the apps will consume from this server.

--- a/examples/package.json
+++ b/examples/package.json
@@ -21,6 +21,7 @@
     "start:uiv24reestyle": "npm run start --workspace=ordersv4freestyle",
     "start:uiv4fpm": "npm run start --workspace=ordersv4fpm",
     "watch:server": "npm run watch --workspace=@capire/orders",
+    "start:launchpad": "npm run watch:launchpad --workspace=@capire/orders",
     "test": "wdio run ./test/wdio-base.conf.js",
     "test:single": "npm run test -- ordersv2fe  96 --spec ./test/specs/all/OpenSpreadsheetUploadDialog.test.js",
     "ui5-test-runner": "ui5-test-runner"

--- a/examples/packages/server/package.json
+++ b/examples/packages/server/package.json
@@ -12,12 +12,14 @@
     "anyupload": "0.0.1",
     "cds-launchpad-plugin": "2.2.0",
     "cds-plugin-ui5": "0.13.1",
+    "cross-env": "^7.0.3",
     "ordersv2fe136": "0.0.1",
     "ordersv4fe136": "0.0.1",
     "ordersv4freestyle136": "0.0.1"
   },
   "scripts": {
-    "watch": "cds watch"
+    "watch": "cds watch",
+    "watch:launchpad": "cross-env CDS_PLUGIN_UI5_MODULES={} cds watch --open launchpad.html"
   },
   "cds": {
     "fiori": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -807,6 +807,7 @@
         "anyupload": "0.0.1",
         "cds-launchpad-plugin": "2.2.0",
         "cds-plugin-ui5": "0.13.1",
+        "cross-env": "^7.0.3",
         "ordersv2fe136": "0.0.1",
         "ordersv4fe136": "0.0.1",
         "ordersv4freestyle136": "0.0.1"
@@ -24782,6 +24783,25 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "npm-run-all --parallel start:server start:v4fe",
+    "start:launchpad": "npm run start:launchpad --workspace=ui5-cc-spreadsheetimporter-sample",
     "start:v2fe": "npm run start --workspace=ordersv2fe136",
     "start:v4fe": "npm run start --workspace=ordersv4fe136",
     "start:anyupload": "npm run start --workspace=anyupload",


### PR DESCRIPTION
## What

Adds a one-command dev flow that boots the CAP server **and** serves all the main test apps behind a Fiori Launchpad in a single process — no separate `fiori run` terminals/ports:

```sh
npm run start:launchpad
```

Auto-opens <http://localhost:4004/launchpad.html>. Apps are served **from source with live reload**.

## Why

The launchpad infra (`cds-plugin-ui5` + `cds-launchpad-plugin`) already existed, but only as the dist-based Docker live demo. This makes it usable for everyday local development of all apps at once, instead of starting the CAP server and each UI5 app separately.

## How

- `start:launchpad` script chain (root → examples → server), mirroring the existing `start:server`.
- The server script sets `CDS_PLUGIN_UI5_MODULES={}`, which fully replaces the committed `cds-plugin-ui5.modules` config so every app falls back to its source `ui5.yaml` (live reload) instead of `ui5-dist.yaml`. **The Docker/live-demo dist path is untouched.**
- Adds `cross-env` devDependency for cross-platform env-var handling (lockfile change is limited to `cross-env`).
- Documented in `docs/pages/Development/GettingStarted.md`.

Apps shown: `ordersv2fe`, `ordersv4fe`, `ordersv4freestyle`, `anyupload` (those that are server devDependencies and have `crossNavigation.inbounds` in their manifest). The wdi5 tests are unaffected — they still launch each app standalone on its own port.

## Verification

Booted locally against the latest `main`: all 4 apps mount from source, the launchpad generates 7 tiles (4 apps + 3 links), and both V4 and V2 (cov2ap) OData services respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
