### PR TITLE
fix: isolate V2 importer writes in a dedicated request group (#231)

### DIFF
--- a/examples/test/specs/all/UploadFilePreserveEdit.test.js
+++ b/examples/test/specs/all/UploadFilePreserveEdit.test.js
@@ -145,14 +145,7 @@ describe("Preserve user's pending changes on upload (#231)", () => {
 		await browser.asControl({
 			selector: { controlType: "sap.m.Dialog", properties: { contentWidth: "40vw" }, searchOpenDialogs: true }
 		});
-		try {
-			await browser.execute(function () {
-				const b = document.getElementById("sap-ui-blocklayer-popup");
-				if (b) b.remove();
-			});
-		} catch (e) {
-			/* nothing */
-		}
+		await BaseClass.removeBlockLayer();
 
 		const uploader = await browser.asControl({
 			forceSelect: true,
@@ -180,14 +173,7 @@ describe("Preserve user's pending changes on upload (#231)", () => {
 	});
 
 	it("close the error dialog (runs the importer cleanup / resetContexts)", async () => {
-		try {
-			await browser.execute(function () {
-				const b = document.getElementById("sap-ui-blocklayer-popup");
-				if (b) b.remove();
-			});
-		} catch (e) {
-			/* nothing */
-		}
+		await BaseClass.removeBlockLayer();
 		// fire the press handler directly (the MessageView list can intercept a DOM click in headless):
 		// Close -> onCloseMessageDialog -> spreadsheetUploadController.resetContent() -> resetContexts()
 		const closeBtn = await browser.asControl({
@@ -209,6 +195,162 @@ describe("Preserve user's pending changes on upload (#231)", () => {
 
 	after(async () => {
 		// discard the manual edit so we don't pollute other specs / the backend
+		try {
+			await browser.execute(function (tableId) {
+				function byId(id) {
+					const E = sap.ui.require("sap/ui/core/Element");
+					return E && E.getElementById ? E.getElementById(id) : sap.ui.getCore().byId(id);
+				}
+				const oTable = byId(tableId);
+				const oModel = oTable && oTable.getModel();
+				if (oModel && oModel.resetChanges) {
+					oModel.resetChanges();
+				}
+			}, FE.objectPageOrderItems);
+		} catch (error) {
+			/* best-effort cleanup */
+		}
+	});
+});
+
+// Companion to the test above, for the SUCCESS path: a successful upload must not COMMIT the
+// user's unrelated pending edit either. Without group isolation, the importer's submitChanges()
+// (no group) flushes the whole model and commits the user's edit; with a dedicated deferred group
+// it submits only the importer's rows, leaving the user's edit pending until they Save/Cancel.
+describe("Do not commit the user's pending changes on a successful upload (#231)", () => {
+	let editedValue2 = undefined;
+
+	before(function () {
+		const scenario = global.scenario;
+		if (!scenario || !scenario.startsWith("ordersv2fenondraft")) {
+			this.skip();
+			return;
+		}
+		FE = new FEV2ND();
+		BaseClass = new Base();
+	});
+
+	it("go to object page", async () => {
+		const hash = `#/${FE.entitySet}(${FE.entityObjectPage})`;
+		await browser.goTo({ sHash: hash });
+		// The error-path describe above shares this browser session and leaves its upload dialog open;
+		// reload to guarantee a clean UI state (no leftover dialogs) before this scenario.
+		await browser.refresh();
+		await ui5Service.injectUI5();
+		await BaseClass.dummyWait(1000);
+		await browser.waitUntil(
+			async () => {
+				const btn = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageEditButton } });
+				return !!btn && !!btn._domId;
+			},
+			{ timeout: 90000, interval: 1000, timeoutMsg: "Object page edit button did not render" }
+		);
+	});
+
+	it("go to edit mode", async () => {
+		await BaseClass.pressById(FE.objectPageEditButton);
+		await BaseClass.dummyWait(3000);
+		const object = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageEditButton } });
+		if (object._domId) {
+			await browser.refresh();
+			await ui5Service.injectUI5();
+			await browser.waitUntil(
+				async () => {
+					const btn = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageEditButton } });
+					return !!btn && !!btn._domId;
+				},
+				{ timeout: 90000, interval: 1000, timeoutMsg: "Object page edit button did not render after refresh" }
+			);
+		}
+		const object2 = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageEditButton } });
+		if (object2._domId) {
+			await BaseClass.pressById(FE.objectPageEditButton);
+			await BaseClass.dummyWait(3000);
+		}
+		await browser.waitUntil(
+			async () => {
+				const save = await browser.asControl({ forceSelect: true, selector: { id: FE.objectPageSaveButton } });
+				return !!save && !!save._domId;
+			},
+			{ timeout: 30000, interval: 1000, timeoutMsg: "Did not enter edit mode (save button not found)" }
+		);
+	});
+
+	it("make an unrelated manual edit on the order header", async () => {
+		const result = await browser.execute(function (tableId) {
+			function byId(id) {
+				const E = sap.ui.require("sap/ui/core/Element");
+				return E && E.getElementById ? E.getElementById(id) : sap.ui.getCore().byId(id);
+			}
+			const oTable = byId(tableId);
+			const oModel = oTable.getModel();
+			const oHeaderCtx = oTable.getBindingContext();
+			const oldValue = oModel.getProperty("OrderNo", oHeaderCtx) || "";
+			const newValue = oldValue + "-OK231";
+			oModel.setProperty("OrderNo", newValue, oHeaderCtx);
+			return { newValue: newValue, headerPath: oHeaderCtx.getPath() };
+		}, FE.objectPageOrderItems);
+		editedValue2 = result.newValue;
+		const before = await readHeaderPending(FE.objectPageOrderItems, "OrderNo");
+		expect(before.hasHeaderChange).toBe(true);
+		expect(before.changedValue).toBe(editedValue2);
+	});
+
+	it("upload a VALID file and let the importer submit it", async () => {
+		await BaseClass.dummyWait(500);
+		await BaseClass.pressById(FE.objectPageSpreadsheetuploadButton);
+		await browser.asControl({
+			selector: { controlType: "sap.m.Dialog", properties: { contentWidth: "40vw" }, searchOpenDialogs: true }
+		});
+		await BaseClass.removeBlockLayer();
+		const uploader = await browser.asControl({
+			forceSelect: true,
+			selector: { interaction: "root", controlType: "sap.ui.unified.FileUploader", searchOpenDialogs: true }
+		});
+		const remoteFilePath = await browser.uploadFile("test/testFiles/TwoRowsNoErrors.xlsx");
+		const $uploader = await uploader.getWebElement();
+		const $fileInput = await $uploader.$("input[type=file]");
+		await $fileInput.setValue(remoteFilePath);
+		await browser.asControl({ selector: { controlType: "sap.m.Button", properties: { text: "Upload" }, searchOpenDialogs: true } }).press();
+
+		// A successful upload closes the dialog (no "Upload Error"); this also runs resetContent/resetContexts.
+		await browser.waitUntil(
+			async () => {
+				const dlg = await browser.asControl({
+					forceSelect: true,
+					selector: { controlType: "sap.m.Dialog", properties: { contentWidth: "40vw" }, searchOpenDialogs: true }
+				});
+				return !dlg || !dlg._domId;
+			},
+			{ timeout: 60000, interval: 1000, timeoutMsg: "Upload dialog did not close (upload may have errored)" }
+		);
+		await BaseClass.dummyWait(2000);
+	});
+
+	it("the imported rows were actually created (sanity)", async () => {
+		const created = await browser.execute(function (tableId) {
+			function byId(id) {
+				const E = sap.ui.require("sap/ui/core/Element");
+				return E && E.getElementById ? E.getElementById(id) : sap.ui.getCore().byId(id);
+			}
+			const oModel = byId(tableId) && byId(tableId).getModel();
+			// the importer's created rows are submitted -> present in the model's data cache
+			const data = oModel && oModel.getProperty ? oModel.getProperty("/") : {};
+			return Object.keys(data || {}).filter((k) => k.indexOf("OrderItemsND") === 0).length;
+		}, FE.objectPageOrderItems);
+		expect(created).toBeGreaterThan(0);
+	});
+
+	it("the manual header edit must NOT have been committed by the upload (#231)", async () => {
+		const after = await readHeaderPending(FE.objectPageOrderItems, "OrderNo");
+		console.log("AFTER-SUCCESS PENDING: " + JSON.stringify(after));
+		// Current code: submitChanges() (no group) committed the edit -> hasHeaderChange === false (RED).
+		// Isolated code: submitChanges({groupId}) submits only the importer's rows -> edit still pending (GREEN).
+		expect(after.hasHeaderChange).toBe(true);
+		expect(after.changedValue).toBe(editedValue2);
+	});
+
+	after(async () => {
 		try {
 			await browser.execute(function (tableId) {
 				function byId(id) {

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV2.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV2.ts
@@ -23,17 +23,41 @@ export default class ODataV2 extends OData {
   // importer's own changes, never the user's unrelated pending changes (issues #231 / #786).
   private createdEntryContexts: any[] = [];
   private updatedEntityPaths: string[] = [];
+  // Dedicated deferred request group for the importer's own writes, so submit/reset stay isolated
+  // from the user's edits (which collect in the model's default "changes" group). This is the V2
+  // analogue of the V4 path's $$updateGroupId. See issue #231.
+  // A CONSTANT id (not random per instance): handler instances are recreated on every
+  // setContext/dialog reuse, and deferred-group registrations on the shared model are never
+  // removed - random ids would accumulate on the model forever. Registration stays idempotent,
+  // and only one modal upload can run at a time, so instances sharing the group is safe.
+  private importGroupId = 'spreadsheetimporterChanges';
 
   constructor(spreadsheetUploadController: SpreadsheetUpload, messageHandler: MessageHandler, util: Util) {
     super(spreadsheetUploadController, messageHandler, util);
     this.metadataHandler = new MetadataHandlerV2(spreadsheetUploadController);
     this.requestObjects = new ODataV2RequestObjects(this.metadataHandler, messageHandler, util);
   }
+
+  /**
+   * Makes sure the importer's private request group is registered as deferred on the model.
+   * setDeferredGroups REPLACES the model's list, so a host app calling it after our initial
+   * registration silently drops our group - then createEntry/update would fire immediately
+   * (outside our batch and error handling). Re-ensure cheaply before every write/submit.
+   */
+  private ensureImportGroupRegistered(model: ODataModel) {
+    if (model && model.getDeferredGroups().indexOf(this.importGroupId) === -1) {
+      // Concat - never overwrite the default "changes" group, or the user's Fiori Elements
+      // edits (collected there) would be flushed immediately.
+      model.setDeferredGroups(model.getDeferredGroups().concat([this.importGroupId]));
+    }
+  }
   create(model: any, binding: any, payload: any) {
     const submitChangesPromise = (binding: ODataListBinding, payload: any) => {
       return new Promise((resolve, reject) => {
+        this.ensureImportGroupRegistered(this.customBinding.getModel() as ODataModel);
         // @ts-ignore
         let context = (this.customBinding.getModel() as ODataModel).createEntry(this.customBinding.sDeepPath, {
+          groupId: this.importGroupId,
           properties: payload,
           success: () => {
             resolve(context);
@@ -129,7 +153,9 @@ export default class ODataV2 extends OData {
     // per-call override in the V2 model. MERGE with the payload built above gives the
     // intended partial/full-update semantics either way (parity with the V4 PATCH path).
     const updatePromise = new Promise((resolve, reject) => {
+      this.ensureImportGroupRegistered(oDataModel);
       oDataModel.update(entityPath, payloadToSend, {
+        groupId: this.importGroupId,
         success: () => resolve(true),
         error: (err: any) => reject(err)
       });
@@ -172,12 +198,21 @@ export default class ODataV2 extends OData {
     } else {
       this.customBinding = binding;
     }
+    // Register our private deferred group up front. All of the importer's
+    // createEntry/update/submitChanges target this group, so a successful upload submits
+    // ONLY our rows and never commits the user's unrelated pending edits (issue #231).
+    this.ensureImportGroupRegistered(this.customBinding.getModel() as ODataModel);
   }
 
   async submitChanges(model: ODataModel) {
+    // drop the previous batch's response so a transport-level reject below cannot leave a stale
+    // (clean) response behind for checkForErrors to misread as success
+    this.submitChangesResponse = undefined;
+    this.ensureImportGroupRegistered(model);
     const submitChangesPromise = (model: ODataModel) => {
       return new Promise((resolve, reject) => {
         model.submitChanges({
+          groupId: this.importGroupId,
           success: (data: any) => {
             resolve(data);
           },


### PR DESCRIPTION
## Summary

Follow-up to #808. Fully isolates the OData **V2** importer's writes in a dedicated request group, so a *successful* upload no longer commits the end user's unrelated pending edits.

> **Stacked on #808** (base branch `fix/issue-231-preserve-pending-changes`) — it builds on that PR's path-scoped reset. Merge after #808, or retarget to `main` once #808 lands.

## Problem (the half #808 did not cover)

In V2 the importer wrote to the model's **default** request group: `createEntry`/`update` with no `groupId`, and `submitChanges()` with no group. The end user's Fiori Elements edits collect in that same default `"changes"` group, so a successful upload's `submitChanges()` **also committed the user's unrelated edit** (they never clicked Save), and the importer's rows rode inside the user's `$batch`.

(#808 fixed the data-**loss**-on-error half via path-scoped `resetChanges`; this fixes the auto-**commit**-on-success half.)

## Fix — dedicated deferred group (the V2 analogue of V4's `$$updateGroupId`)

`ODataV2.ts`:
- `createCustomBinding` registers a private deferred group: `model.setDeferredGroups(model.getDeferredGroups().concat([importGroupId]))` — **concat**, so FE's default `"changes"` group is never overwritten (overwriting it would make FE's collected edits fire immediately).
- `createEntry`, `update`, and `submitChanges` all pass `{ groupId: importGroupId }`.

A successful upload now submits **only** the importer's rows; the user's pending edits stay in `"changes"` untouched until they Save/Cancel. The path-scoped `resetContexts` cleanup from #808 is unchanged.

This follows SAP's documented V2 isolation pattern (deferred request group + `submitChanges({groupId})`), the direct analogue of the V4 path that already uses `$$updateGroupId`.

## Testing

New success-path regression in `examples/test/specs/all/UploadFilePreserveEdit.test.js` (guarded to `ordersv2fenondraft`): with a pending Order-header edit, a successful upload must create the rows but must **not** commit that edit. Verified **red → green** (header committed on the old code → preserved with isolation).

Local runs (UI5 1.136, headless):
- `ordersv2fenondraft` UploadFilePreserveEdit (error + success paths) — 12/12 ✓
- `ordersv2fenondraft` normal upload — 16/16 ✓
- `ordersv2fe` (V2 **draft**) upload — 16/16 ✓
- `ui5lint`: 0 errors · `prettier --check`: clean

V4 is untouched by these V2-only changes.

## Refs
- Builds on #808 · Fixes the remaining auto-commit half of #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)