### PR TITLE
docs: quote nav title with colon to unbreak mkdocs deploy

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ nav:
       - GitHub Actions: pages/Development/GitHubActions.md
       - Sample Apps: pages/Development/SampleApps.md
       - Spreadsheet Download: pages/Development/SpreadsheetDownload.md
-      - OData V2: Export and Update: pages/Development/ODataV2-ExportAndUpdate.md
+      - 'OData V2: Export and Update': pages/Development/ODataV2-ExportAndUpdate.md
       - Project Setup: pages/Development/ProjectSetup.md
 
 theme:


### PR DESCRIPTION
## Problem

The `main` docs deploy is failing on [run 27232469902](https://github.com/spreadsheetimporter/ui5-cc-spreadsheetimporter/actions/runs/27232469902/job/80415885344):

```
Error: MkDocs encountered an error parsing the configuration file: mapping values are not allowed here
  in ".../mkdocs.yml", line 46, column 36
```

The nav entry added in #807 had an **unquoted colon** in its title:

```yaml
- OData V2: Export and Update: pages/Development/ODataV2-ExportAndUpdate.md
```

YAML reads `OData V2` as the key, then hits a second colon (`Export and Update:`) inside the value at column 36 and interprets it as an illegal nested mapping — aborting the build.

## Fix

Quote the title so the embedded colon is treated as literal text:

```yaml
- 'OData V2: Export and Update': pages/Development/ODataV2-ExportAndUpdate.md
```

## Verification

- `mkdocs build` now completes: `Documentation built in 0.74 seconds` (ran in an isolated venv with `mkdocs-material` + `mkdocs-minify-plugin`, matching the CI deploy job).
- The `mapping values are not allowed here` error is gone.
- Confirmed the referenced page `docs/pages/Development/ODataV2-ExportAndUpdate.md` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)